### PR TITLE
Market icon badge bug

### DIFF
--- a/Troika/Components/MarketGrid/MarketGridCell/MarketGridCell.swift
+++ b/Troika/Components/MarketGrid/MarketGridCell/MarketGridCell.swift
@@ -87,6 +87,7 @@ public class MarketGridCell: UICollectionViewCell {
     public override func prepareForReuse() {
         super.prepareForReuse()
         iconImageView.image = nil
+        badgeImageView.image = nil
         titleLabel.text = ""
         accessibilityLabel = ""
     }


### PR DESCRIPTION
# What?
Clears market grid cell badge when preparing for reuse.