### PR TITLE
Button margins to avoid truncation

### DIFF
--- a/Troika/Components/Button/Button+Style.swift
+++ b/Troika/Components/Button/Button+Style.swift
@@ -91,5 +91,12 @@ public extension Button {
             default: return .sardine
             }
         }
+
+        var margins: UIEdgeInsets {
+            switch self {
+            case .link: return UIEdgeInsets(top: .smallSpacing, left: 0, bottom: .smallSpacing, right: 0)
+            default: return UIEdgeInsets(top: .smallSpacing, left: .mediumSpacing, bottom: .smallSpacing, right: .mediumSpacing)
+            }
+        }
     }
 }

--- a/Troika/Components/Button/Button.swift
+++ b/Troika/Components/Button/Button.swift
@@ -29,8 +29,7 @@ public class Button: UIButton {
     private func setup() {
         isAccessibilityElement = true
 
-        titleEdgeInsets = UIEdgeInsets(top: 0, left: .mediumSpacing, bottom: 0, right: .mediumSpacing)
-
+        contentEdgeInsets = style.margins
         titleLabel?.font = style.font
         layer.cornerRadius = cornerRadius
         layer.borderWidth = style.borderWidth

--- a/Troika/Components/Button/Playground/ButtonPlayground.swift
+++ b/Troika/Components/Button/Playground/ButtonPlayground.swift
@@ -91,11 +91,10 @@ public class ButtonPlayground: UIView {
 
             button1.topAnchor.constraint(equalTo: linkButton.bottomAnchor, constant: .largeSpacing),
             button1.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
-            button1.widthAnchor.constraint(equalToConstant: frame.width / 2 - .largeSpacing - .mediumSpacing),
+            button1.trailingAnchor.constraint(lessThanOrEqualTo: button2.leadingAnchor),
 
             button2.topAnchor.constraint(equalTo: button1.topAnchor),
             button2.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
-            button2.widthAnchor.constraint(equalToConstant: frame.width / 2 - .largeSpacing - .mediumSpacing),
 
             disabledNormalButton.topAnchor.constraint(equalTo: button1.bottomAnchor, constant: .largeSpacing),
             disabledNormalButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),


### PR DESCRIPTION
# What?
Changes the `titleEdgeInsets` to a `contentEdgeInsets` so that the size of the button itself changes and not the title content bounds. Adds `margins` to the _button style_ to that for the button styles without borders will be aligned with text etc.

# Why?
Improvement on the button class to make it more usable.

# Screenshots
![skjermbilde 2017-12-06 kl 09 11 49](https://user-images.githubusercontent.com/15629801/33651285-84f567a4-da65-11e7-9714-1802434634c0.png)

![skjermbilde 2017-12-06 kl 09 07 32](https://user-images.githubusercontent.com/15629801/33651268-7ab6ebe6-da65-11e7-95d0-7124f80f6d15.png)
