### PR TITLE
Change button styles

### DIFF
--- a/Troika/Components/Button/Button+Style.swift
+++ b/Troika/Components/Button/Button+Style.swift
@@ -10,6 +10,7 @@ public extension Button {
         case `default`
         case callToAction
         case destructive
+        case flat
         case link
 
         var font: UIFont {
@@ -21,7 +22,7 @@ public extension Button {
 
         var bodyColor: UIColor {
             switch self {
-            case .default, .link: return .milk
+            case .default, .link, .flat: return .milk
             case .callToAction: return .primaryBlue
             case .destructive: return .cherry
             }
@@ -43,7 +44,7 @@ public extension Button {
 
         var textColor: UIColor {
             switch self {
-            case .default, .link: return .primaryBlue
+            case .default, .link, .flat: return .primaryBlue
             default: return .milk
             }
         }
@@ -66,14 +67,14 @@ public extension Button {
 
         var highlightedTextColor: UIColor? {
             switch self {
-            case .link: return UIColor(red: 0 / 255, green: 79 / 255, blue: 201 / 255, alpha: 1.0) // #004fc9
+            case .link, .flat: return UIColor(red: 0 / 255, green: 79 / 255, blue: 201 / 255, alpha: 1.0) // #004fc9
             default: return nil
             }
         }
 
         var disabledBodyColor: UIColor? {
             switch self {
-            case .default, .link: return nil
+            case .default, .link, .flat: return nil
             default: return .sardine
             }
         }
@@ -94,8 +95,8 @@ public extension Button {
 
         var margins: UIEdgeInsets {
             switch self {
-            case .link: return UIEdgeInsets(top: .smallSpacing, left: 0, bottom: .smallSpacing, right: 0)
-            default: return UIEdgeInsets(top: .smallSpacing, left: .mediumSpacing, bottom: .smallSpacing, right: .mediumSpacing)
+            case .link, .flat: return UIEdgeInsets(top: .smallSpacing, left: 0, bottom: .smallSpacing, right: 0)
+            default: return UIEdgeInsets(top: .mediumSpacing, left: .mediumSpacing, bottom: .mediumSpacing, right: .mediumSpacing)
             }
         }
     }

--- a/Troika/Components/Button/Button+Style.swift
+++ b/Troika/Components/Button/Button+Style.swift
@@ -8,7 +8,7 @@ public extension Button {
 
     public enum Style {
         case `default`
-        case flat
+        case callToAction
         case destructive
         case link
 
@@ -22,7 +22,7 @@ public extension Button {
         var bodyColor: UIColor {
             switch self {
             case .default, .link: return .milk
-            case .flat: return .primaryBlue
+            case .callToAction: return .primaryBlue
             case .destructive: return .cherry
             }
         }
@@ -50,7 +50,7 @@ public extension Button {
 
         var highlightedBodyColor: UIColor? {
             switch self {
-            case .flat: return UIColor(red: 0 / 255, green: 79 / 255, blue: 201 / 255, alpha: 1.0) // #004fc9
+            case .callToAction: return UIColor(red: 0 / 255, green: 79 / 255, blue: 201 / 255, alpha: 1.0) // #004fc9
             case .destructive: return UIColor(red: 201 / 255, green: 79 / 255, blue: 0 / 255, alpha: 1.0)
             case .default: return UIColor(red: 241 / 255, green: 249 / 255, blue: 255 / 255, alpha: 1.0)
             default: return nil
@@ -87,7 +87,7 @@ public extension Button {
 
         var disabledTextColor: UIColor? {
             switch self {
-            case .flat, .destructive: return nil
+            case .callToAction, .destructive: return nil
             default: return .sardine
             }
         }

--- a/Troika/Components/Button/Playground/ButtonPlayground.swift
+++ b/Troika/Components/Button/Playground/ButtonPlayground.swift
@@ -16,15 +16,15 @@ public class ButtonPlayground: UIView {
 
     private func setup() {
         let normalButton = Button(style: .default)
-        let flatButton = Button(style: .flat)
+        let flatButton = Button(style: .callToAction)
         let destructiveButton = Button(style: .destructive)
         let linkButton = Button(style: .link)
 
-        let button1 = Button(style: .flat)
+        let button1 = Button(style: .callToAction)
         let button2 = Button(style: .default)
 
         let disabledNormalButton = Button(style: .default)
-        let disabledFlatButton = Button(style: .flat)
+        let disabledFlatButton = Button(style: .callToAction)
         let disabledDestructiveButton = Button(style: .destructive)
         let disabledLinkButton = Button(style: .link)
 

--- a/Troika/Components/Button/Playground/ButtonPlayground.swift
+++ b/Troika/Components/Button/Playground/ButtonPlayground.swift
@@ -16,99 +16,116 @@ public class ButtonPlayground: UIView {
 
     private func setup() {
         let normalButton = Button(style: .default)
-        let flatButton = Button(style: .callToAction)
+        let callToActionButton = Button(style: .callToAction)
         let destructiveButton = Button(style: .destructive)
+        let flatButton = Button(style: .flat)
         let linkButton = Button(style: .link)
 
         let button1 = Button(style: .callToAction)
         let button2 = Button(style: .default)
 
         let disabledNormalButton = Button(style: .default)
-        let disabledFlatButton = Button(style: .callToAction)
+        let disabledCallToActionButton = Button(style: .callToAction)
         let disabledDestructiveButton = Button(style: .destructive)
+        let disabledFlatButton = Button(style: .flat)
         let disabledLinkButton = Button(style: .link)
 
         normalButton.setTitle("Default button", for: .normal)
-        flatButton.setTitle("Flat button", for: .normal)
+        callToActionButton.setTitle("Call to action button", for: .normal)
         destructiveButton.setTitle("Destructive button", for: .normal)
+        flatButton.setTitle("Flat button", for: .normal)
         linkButton.setTitle("Link button", for: .normal)
 
         button1.setTitle("Left button", for: .normal)
         button2.setTitle("Right button", for: .normal)
 
         disabledNormalButton.setTitle("Disabled default button", for: .normal)
-        disabledFlatButton.setTitle("Disabled flat button", for: .normal)
+        disabledCallToActionButton.setTitle("Disabled call to action button", for: .normal)
         disabledDestructiveButton.setTitle("Disabled destructive button", for: .normal)
+        disabledFlatButton.setTitle("Disabled flat button", for: .normal)
         disabledLinkButton.setTitle("Disabled link button", for: .normal)
 
         disabledNormalButton.isEnabled = false
-        disabledFlatButton.isEnabled = false
+        disabledCallToActionButton.isEnabled = false
         disabledDestructiveButton.isEnabled = false
+        disabledFlatButton.isEnabled = false
         disabledLinkButton.isEnabled = false
 
         normalButton.translatesAutoresizingMaskIntoConstraints = false
-        flatButton.translatesAutoresizingMaskIntoConstraints = false
+        callToActionButton.translatesAutoresizingMaskIntoConstraints = false
         destructiveButton.translatesAutoresizingMaskIntoConstraints = false
+        flatButton.translatesAutoresizingMaskIntoConstraints = false
         linkButton.translatesAutoresizingMaskIntoConstraints = false
 
         button1.translatesAutoresizingMaskIntoConstraints = false
         button2.translatesAutoresizingMaskIntoConstraints = false
 
         disabledNormalButton.translatesAutoresizingMaskIntoConstraints = false
-        disabledFlatButton.translatesAutoresizingMaskIntoConstraints = false
+        disabledCallToActionButton.translatesAutoresizingMaskIntoConstraints = false
         disabledDestructiveButton.translatesAutoresizingMaskIntoConstraints = false
+        disabledFlatButton.translatesAutoresizingMaskIntoConstraints = false
         disabledLinkButton.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(normalButton)
-        addSubview(flatButton)
+        addSubview(callToActionButton)
         addSubview(destructiveButton)
+        addSubview(flatButton)
         addSubview(linkButton)
 
         addSubview(button1)
         addSubview(button2)
 
         addSubview(disabledNormalButton)
-        addSubview(disabledFlatButton)
+        addSubview(disabledCallToActionButton)
         addSubview(disabledDestructiveButton)
+        addSubview(disabledFlatButton)
         addSubview(disabledLinkButton)
 
         NSLayoutConstraint.activate([
-            normalButton.topAnchor.constraint(equalTo: topAnchor, constant: .largeSpacing),
+            normalButton.topAnchor.constraint(equalTo: topAnchor, constant: .mediumLargeSpacing),
             normalButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
             normalButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
 
-            flatButton.topAnchor.constraint(equalTo: normalButton.bottomAnchor, constant: .largeSpacing),
-            flatButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
-            flatButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
+            callToActionButton.topAnchor.constraint(equalTo: normalButton.bottomAnchor, constant: .mediumLargeSpacing),
+            callToActionButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
+            callToActionButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
 
-            destructiveButton.topAnchor.constraint(equalTo: flatButton.bottomAnchor, constant: .largeSpacing),
+            destructiveButton.topAnchor.constraint(equalTo: callToActionButton.bottomAnchor, constant: .mediumLargeSpacing),
             destructiveButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
             destructiveButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
 
-            linkButton.topAnchor.constraint(equalTo: destructiveButton.bottomAnchor, constant: .largeSpacing),
+            flatButton.topAnchor.constraint(equalTo: destructiveButton.bottomAnchor, constant: .mediumLargeSpacing),
+            flatButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
+            flatButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
+
+            linkButton.topAnchor.constraint(equalTo: flatButton.bottomAnchor, constant: .mediumLargeSpacing),
             linkButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
             linkButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
 
-            button1.topAnchor.constraint(equalTo: linkButton.bottomAnchor, constant: .largeSpacing),
+            button1.topAnchor.constraint(equalTo: linkButton.bottomAnchor, constant: .mediumLargeSpacing),
             button1.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
             button1.trailingAnchor.constraint(lessThanOrEqualTo: button2.leadingAnchor),
 
             button2.topAnchor.constraint(equalTo: button1.topAnchor),
             button2.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
 
-            disabledNormalButton.topAnchor.constraint(equalTo: button1.bottomAnchor, constant: .largeSpacing),
+            disabledNormalButton.topAnchor.constraint(equalTo: button1.bottomAnchor, constant: .mediumLargeSpacing),
             disabledNormalButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
             disabledNormalButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
 
-            disabledFlatButton.topAnchor.constraint(equalTo: disabledNormalButton.bottomAnchor, constant: .mediumLargeSpacing),
-            disabledFlatButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
-            disabledFlatButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
+            disabledCallToActionButton.topAnchor.constraint(equalTo: disabledNormalButton.bottomAnchor, constant: .mediumLargeSpacing),
+            disabledCallToActionButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
+            disabledCallToActionButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
 
-            disabledDestructiveButton.topAnchor.constraint(equalTo: disabledFlatButton.bottomAnchor, constant: .mediumLargeSpacing),
+            disabledDestructiveButton.topAnchor.constraint(equalTo: disabledCallToActionButton.bottomAnchor, constant: .mediumLargeSpacing),
             disabledDestructiveButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
             disabledDestructiveButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
 
-            disabledLinkButton.topAnchor.constraint(equalTo: disabledDestructiveButton.bottomAnchor, constant: .mediumLargeSpacing),
+            disabledFlatButton.topAnchor.constraint(equalTo: disabledDestructiveButton.bottomAnchor, constant: .mediumLargeSpacing),
+            disabledFlatButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
+            disabledFlatButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
+
+            disabledLinkButton.topAnchor.constraint(equalTo: disabledFlatButton.bottomAnchor, constant: .mediumLargeSpacing),
             disabledLinkButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .largeSpacing),
             disabledLinkButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -.largeSpacing),
         ])

--- a/Troika/Components/Login/LoginView.swift
+++ b/Troika/Components/Login/LoginView.swift
@@ -51,7 +51,7 @@ public class LoginView: UIView {
     }()
 
     private lazy var loginButton: Button = {
-        let button = Button(style: .flat)
+        let button = Button(style: .callToAction)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(loginTapped), for: .touchUpInside)
         return button


### PR DESCRIPTION
# What?
Renaming the `.flat` button style to `.callToAction` and adds a different `.flat` style which follows the way it is explained in _finninvers_. All the styles are depicted below with their disabled version.

(the _Left button_ and _Right button_ are still just to show how the button looks when no `widthAnchor` is set. They are not separate styles)

# Why?
I misunderstood the explanation on _finnivers_ at first, but now we have all the desired buttons.

# Screenshot
![simulator screen shot - iphone 8 plus - 2017-12-08 at 09 49 47](https://user-images.githubusercontent.com/15629801/33758277-debec8e0-dbfd-11e7-9520-e3d2c227cc4f.png)
