### PR TITLE
Use generic extension to dequeue a cell in PreviewGridView

### DIFF
--- a/Sources/Components/PreviewGrid/PreviewGridView/PreviewGridView.swift
+++ b/Sources/Components/PreviewGrid/PreviewGridView/PreviewGridView.swift
@@ -119,7 +119,7 @@ extension PreviewGridView: UICollectionViewDataSource {
     }
 
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: String(describing: PreviewGridCell.self), for: indexPath) as! PreviewGridCell
+        let cell = collectionView.dequeue(PreviewGridCell.self, for: indexPath)
 
         // Show a pretty color while we load the image
         let colors: [UIColor] = [.toothPaste, .mint, .banana, .salmon]


### PR DESCRIPTION
Hi,

I've found a generic extension for dequeuing a cell, however, I also found a case when it wasn't used.

As a side note, you could declare extension like this:
```Swift
  func dequeueCell<T: ReusableCell>(for indexPath: IndexPath) -> T {
    return self.dequeueReusableCell(withIdentifier: T.reuseIdentifier(), for: indexPath) as! T
  }
```
And dequeue cell without passing `CellClass` at all, it will be inferred:
```Swift
let cell: MenuCell = tableView.dequeueCell(for: indexPath)
```
or, maybe you have some reasons for not using this style?

Anyway, I like the idea of codifying a design system like this.