### PR TITLE
changed corner radius

### DIFF
--- a/Sources/Components/Button/Button.swift
+++ b/Sources/Components/Button/Button.swift
@@ -8,7 +8,7 @@ public class Button: UIButton {
 
     // MARK: - Internal properties
 
-    private let cornerRadius: CGFloat = 4.0
+    private let cornerRadius: CGFloat = 8.0
 
     // MARK: - External properties
 

--- a/Sources/Components/Ribbon/RibbonView.swift
+++ b/Sources/Components/Ribbon/RibbonView.swift
@@ -17,7 +17,7 @@ public class RibbonView: UIView {
 
     let horisontalMargin: CGFloat = 8
     let verticalMargin: CGFloat = 2
-    let cornerRadius: CGFloat = 3
+    let cornerRadius: CGFloat = 8
 
     // MARK: - External properties
 


### PR DESCRIPTION
What?
changed corner-radius from 4 and 3 to 8 for buttons and ribbons.

Why?
More rounded corners is more friendly, and matches the guidelines in zeplin.

![buttons-after](https://user-images.githubusercontent.com/27729512/35555075-4f319d54-059e-11e8-8de1-a12981acaab3.png)
![buttons-before](https://user-images.githubusercontent.com/27729512/35555076-4f487cb8-059e-11e8-9521-56a0caf5f8c0.png)
![ribbon-after](https://user-images.githubusercontent.com/27729512/35555077-4f5e60f0-059e-11e8-9d85-0e6b5c85dfdf.png)
![ribbon-before](https://user-images.githubusercontent.com/27729512/35555078-4f73cf4e-059e-11e8-824b-a3f1ff7b6804.png)
